### PR TITLE
Configure okta client id from the command line to support multiple OIDC apps

### DIFF
--- a/ice-spa-app/build/webpack.dev.conf.js
+++ b/ice-spa-app/build/webpack.dev.conf.js
@@ -20,7 +20,8 @@ module.exports = merge(baseWebpackConfig, {
   plugins: [
     new webpack.DefinePlugin({
       'process.env': config.dev.env,
-      'nav.purple': `"${process.env.NAV_PURPLE ? process.env.NAV_PURPLE : ''}"`
+      'nav.purple': `"${process.env.NAV_PURPLE ? process.env.NAV_PURPLE : ''}"`,
+      'okta.client.id': `"${process.env.OKTA_CLIENT_ID ? process.env.OKTA_CLIENT_ID : ''}"`
     }),
     // https://github.com/glenjamin/webpack-hot-middleware#installation--usage
     new webpack.HotModuleReplacementPlugin(),

--- a/ice-spa-app/src/auth/index.js
+++ b/ice-spa-app/src/auth/index.js
@@ -5,7 +5,7 @@ import router from '../router' //router: required to redirect users
 // const OKTA_ORG = 'https://oktaiceXXX.oktapreview.com';
 // const AUTHZ_SERVER = OKTA_ORG;
 // const AUTHZ_URL = AUTHZ_SERVER + '/oauth2/v1/authorize';
-// const CLIENT_ID = '0oaxxxxxxxxxxxxx';
+// const CLIENT_ID = okta.client.id; // command line env var: OKTA_CLIENT_ID
 // const REDIRECT_URL = window.location.origin + '/redirect';
 // const SCOPES = ['openid', 'profile', 'email'];
 // const TOKENS = ['token', 'id_token'];

--- a/ice-spa-app_apiam_completed/build/webpack.dev.conf.js
+++ b/ice-spa-app_apiam_completed/build/webpack.dev.conf.js
@@ -20,7 +20,8 @@ module.exports = merge(baseWebpackConfig, {
   plugins: [
     new webpack.DefinePlugin({
       'process.env': config.dev.env,
-      'nav.purple': `"${process.env.NAV_PURPLE ? process.env.NAV_PURPLE : ''}"`
+      'nav.purple': `"${process.env.NAV_PURPLE ? process.env.NAV_PURPLE : ''}"`,
+      'okta.client.id': `"${process.env.OKTA_CLIENT_ID ? process.env.OKTA_CLIENT_ID : ''}"`
     }),
     // https://github.com/glenjamin/webpack-hot-middleware#installation--usage
     new webpack.HotModuleReplacementPlugin(),

--- a/ice-spa-app_apiam_completed/src/auth/index.js
+++ b/ice-spa-app_apiam_completed/src/auth/index.js
@@ -5,7 +5,7 @@ import OktaAuth from '@okta/okta-auth-js' //okta authjs: required login in Okta
 const OKTA_ORG = 'https://oktaiceXXX.oktapreview.com';
 const AUTHZ_SERVER = OKTA_ORG + '/oauth2/axxxxxxxxxxxxxx';
 const AUTHZ_URL = AUTHZ_SERVER + '/v1/authorize';
-const CLIENT_ID = '0oaaaaaaaaaaaaaaaaaa';
+const CLIENT_ID = okta.client.id; // command line env var: OKTA_CLIENT_ID
 const REDIRECT_URL = window.location.origin + '/redirect';
 const SCOPES = ['openid', 'profile', 'email', 'promos:read'];
 const TOKENS = ['token', 'id_token'];

--- a/ice-spa-app_sso_completed/build/webpack.dev.conf.js
+++ b/ice-spa-app_sso_completed/build/webpack.dev.conf.js
@@ -20,7 +20,8 @@ module.exports = merge(baseWebpackConfig, {
   plugins: [
     new webpack.DefinePlugin({
       'process.env': config.dev.env,
-      'nav.purple': `"${process.env.NAV_PURPLE ? process.env.NAV_PURPLE : ''}"`
+      'nav.purple': `"${process.env.NAV_PURPLE ? process.env.NAV_PURPLE : ''}"`,
+      'okta.client.id': `"${process.env.OKTA_CLIENT_ID ? process.env.OKTA_CLIENT_ID : ''}"`
     }),
     // https://github.com/glenjamin/webpack-hot-middleware#installation--usage
     new webpack.HotModuleReplacementPlugin(),

--- a/ice-spa-app_sso_completed/src/auth/index.js
+++ b/ice-spa-app_sso_completed/src/auth/index.js
@@ -5,7 +5,7 @@ import OktaAuth from '@okta/okta-auth-js' //okta authjs: required login in Okta
 const OKTA_ORG = 'https://oktaiceXXX.oktapreview.com';
 const AUTHZ_SERVER = OKTA_ORG;
 const AUTHZ_URL = AUTHZ_SERVER + '/oauth2/v1/authorize';
-const CLIENT_ID = '0oaaaaaaaaaaaaaaaaaa';
+const CLIENT_ID = okta.client.id; // command line env var: OKTA_CLIENT_ID
 const REDIRECT_URL = window.location.origin + '/redirect';
 const SCOPES = ['openid', 'profile', 'email'];
 const TOKENS = ['token', 'id_token'];


### PR DESCRIPTION
@chrisbarry-okta - This change would allow us to reference two different Okta OIDC clients from the same code base.

The instructions would be:

```
PORT=8080 OKTA_CLIENT_ID=aaaaaa npm start

PORT=8081 OKTA_CLIENT_ID=bbbbbb NAV_PURPLE=true npm start
```

This way, we could show the different app username again.

What do you think?

pros: we get to distinguish app profile and show SSO across multiple browser apps and multiple okta clients.

cons: requires a command line parameter for OKTA_CLIENT_ID. They'll still set the okta org in the code. Represents a not insignificant change to the lab guide.